### PR TITLE
Add new projects with GitHub and Discord links

### DIFF
--- a/src/assets/table_data/projects.json
+++ b/src/assets/table_data/projects.json
@@ -1,5 +1,21 @@
 [
   {
+    "githubLink": "https://github.com/brafdlog/caspion",
+    "discordLink": "https://discord.gg/ETF5W7aQ5J"
+  },
+  {
+    "githubLink": "https://github.com/eshaham/israeli-bank-scrapers",
+    "discordLink": "https://discord.gg/4B84qWwNfy"
+  },
+  {
+    "githubLink": "https://github.com/os-scar/overlay",
+    "discordLink": "https://discord.gg/9TuFwgH2EB"
+  },
+  {
+    "githubLink": "https://github.com/Checkmarx/2ms",
+    "discordLink": "https://discord.gg/2A3mCARu2q"
+  },
+  {
     "githubLink": "https://github.com/shootermv/shlezinger.institute",
     "discordLink": "https://discord.gg/TZT6bExp33"
   },


### PR DESCRIPTION
This pull request adds new projects to the `projects.json` file, including their GitHub and Discord links.

[caspion](https://github.com/brafdlog/caspion)
[israeli-bank-scrapers](https://github.com/eshaham/israeli-bank-scrapers)
[overlay](https://github.com/os-scar/overlay)
[2ms](https://github.com/Checkmarx/2ms)
