### PR TITLE
fix: project list table not show in mobile screen

### DIFF
--- a/src/layouts/en/EnArticleLayout.astro
+++ b/src/layouts/en/EnArticleLayout.astro
@@ -18,7 +18,7 @@ const { collection } = Astro.props;
     <Header />
     <main class="flex flex-col md:flex-row">
       <SideNav collection={collection} />
-      <article class="mx-6 py-2 prose max-w-[calc(100vw_-_392px)]">
+      <article class="mx-6 py-2 prose max-w-full md:max-w-[calc(100vw_-_392px)]">
         <slot />
       </article>
     </main>


### PR DESCRIPTION
fix for issue:
[https://github.com/Maakaf/maakaf-temp/issues/110](url)
Note:
Now the table is displayed but in order to see every column you need to use right-left scrolling.

**After the fix:**

![localhost_4321_en_members_en_projects_list(iPhone 12 Pro)](https://github.com/Maakaf/maakaf-temp/assets/6542413/05b452b5-bb4a-43e8-9835-919b7d0ac449)

